### PR TITLE
Fix problem where hover tags were hidden

### DIFF
--- a/css/animal_selector.styl
+++ b/css/animal_selector.styl
@@ -174,7 +174,7 @@
         position: absolute;
         width: 100%;
         z-index: 1;
-        overflow: scroll;
+        overflow: visible;
 
         &.hidden {
           display: none;


### PR DESCRIPTION
This ensures the hovers on e.g. Horns buttons cannot get hidden under the outer containing div.