### PR TITLE
Launch blank images experiment 1, plus experimental fixes

### DIFF
--- a/app/controllers/animal_details.coffee
+++ b/app/controllers/animal_details.coffee
@@ -3,6 +3,7 @@ template = require 'views/animal_details'
 PopupButton = require './popup_button'
 ImageChanger = require './image_changer'
 AnalyticsLogger = require 'lib/analytics'
+ExperimentalSubject = require 'models/experimental_subject'
 
 class AnimalDetails extends Controller
   animal: null
@@ -79,7 +80,7 @@ class AnimalDetails extends Controller
     @hide()
 
   onClickIdentify: ->
-    AnalyticsLogger.logEvent 'identify', @animal.id
+    AnalyticsLogger.logEvent 'identify', @animal.id, ExperimentalSubject.current?.zooniverseId
     @classification.annotate
       species: @animal
 

--- a/app/controllers/subject_viewer.coffee
+++ b/app/controllers/subject_viewer.coffee
@@ -150,7 +150,7 @@ class SubjectViewer extends Controller
   #   delete @mouseDown
 
   onClickPlay: ->
-    AnalyticsLogger.logEvent 'play', @classification.id, null, @classification.subject.zooniverseId
+    AnalyticsLogger.logEvent 'play', @classification.id, @classification.subject.zooniverseId
     @play()
 
   onClickPause: ->
@@ -159,47 +159,47 @@ class SubjectViewer extends Controller
   onClickToggle: ({currentTarget}) =>
     selectedIndex = $(currentTarget).val()
     friendlyIndex = 1 + parseInt ($(currentTarget).val())
-    AnalyticsLogger.logEvent 'frame' + friendlyIndex, @classification.id, null, @classification.subject.zooniverseId
+    AnalyticsLogger.logEvent 'frame' + friendlyIndex, @classification.id, @classification.subject.zooniverseId
     @activate selectedIndex
 
   onClickSatellite: ->
     if not @satelliteImage.hasClass 'active'
-      AnalyticsLogger.logEvent 'map', null, null, @classification.subject.zooniverseId
+      AnalyticsLogger.logEvent 'map', null, @classification.subject.zooniverseId
     @satelliteImage.add(@satelliteToggle).toggleClass 'active'
 
   onClickSignIn: ->
     $(window).trigger 'request-login-dialog'
 
   onClickFacebook: ->
-    AnalyticsLogger.logEvent 'facebook', @classification.id, null, @classification.subject.zooniverseId
+    AnalyticsLogger.logEvent 'facebook', @classification.id, @classification.subject.zooniverseId
 
   onClickTweet: ->
-    AnalyticsLogger.logEvent 'tweet', @classification.id, null, @classification.subject.zooniverseId
+    AnalyticsLogger.logEvent 'tweet', @classification.id, @classification.subject.zooniverseId
 
   onClickPin: ->
-    AnalyticsLogger.logEvent 'pin', @classification.id, null, @classification.subject.zooniverseId
+    AnalyticsLogger.logEvent 'pin', @classification.id, @classification.subject.zooniverseId
 
   onClickTalk: ->
-    AnalyticsLogger.logEvent 'talk', @classification.id, null, @classification.subject.zooniverseId
+    AnalyticsLogger.logEvent 'talk', @classification.id, @classification.subject.zooniverseId
 
   onClickFavorite: ->
-    AnalyticsLogger.logEvent 'favorite', @classification.id, null, @classification.subject.zooniverseId
+    AnalyticsLogger.logEvent 'favorite', @classification.id, @classification.subject.zooniverseId
     @classification.updateAttribute 'favorite', true
 
   onClickUnfavorite: ->
-    AnalyticsLogger.logEvent 'unfavorite', @classification.id, null, @classification.subject.zooniverseId
+    AnalyticsLogger.logEvent 'unfavorite', @classification.id, @classification.subject.zooniverseId
     @classification.updateAttribute 'favorite', false
 
   onChangeFireCheckbox: ->
     fire = !!@fireCheckbox.attr 'checked'
     if fire
-      AnalyticsLogger.logEvent 'fire', @classification.id, null, @classification.subject.zooniverseId
+      AnalyticsLogger.logEvent 'fire', @classification.id, @classification.subject.zooniverseId
     @classification.annotate {fire}, true
 
   onChangeNothingCheckbox: ->
     nothing = !!@nothingCheckbox.attr 'checked'
     if nothing
-      AnalyticsLogger.logEvent 'nothing', @classification.id, null, @classification.subject.zooniverseId
+      AnalyticsLogger.logEvent 'nothing', @classification.id, @classification.subject.zooniverseId
     @classification.annotate {nothing}, true
 
   onClickFinish: ->
@@ -208,7 +208,7 @@ class SubjectViewer extends Controller
     @extraMessageContainer.hide() unless message
 
     @el.addClass 'finished'
-    AnalyticsLogger.logEvent 'classify', @classification.id, null, @classification.subject.zooniverseId
+    AnalyticsLogger.logEvent 'classify', @classification.id, @classification.subject.zooniverseId
     @classification.send() unless @classification.subject.metadata.empty
 
   onClickNext: ->

--- a/app/index.coffee
+++ b/app/index.coffee
@@ -18,6 +18,7 @@ User = require 'zooniverse/lib/models/user'
 ExperimentalSubject = require 'models/experimental_subject'
 AnalyticsLogger = require 'lib/analytics'
 googleAnalytics = require 'zooniverse/lib/google_analytics'
+Experiments = require 'lib/experiments'
 # Map = require 'zooniverse/lib/map'
 
 ContentPage = require 'controllers/content_page'
@@ -44,6 +45,7 @@ User.bind 'sign-in', ->
   if User.current?
     AnalyticsLogger.logEvent 'login'
   else
+    Experiments.resetExperimentalFlags()
     AnalyticsLogger.logEvent 'logout'
 
 Api.init

--- a/app/index.coffee
+++ b/app/index.coffee
@@ -30,7 +30,6 @@ navigation = new Navigation
 navigation.el.appendTo document.body
 
 LanguagePicker = require 'controllers/language_picker'
-loggedInUserId = null
 languagePicker = new LanguagePicker
 languagePicker.el.prependTo document.body
 
@@ -44,17 +43,16 @@ User.bind 'sign-in', ->
   $('html').toggleClass 'signed-in', User.current?
   if User.current?
     AnalyticsLogger.logEvent 'login'
-    loggedInUserId = User.current?.zooniverse_id
   else
-    AnalyticsLogger.logEvent 'logout',null,loggedInUserId
+    AnalyticsLogger.logEvent 'logout'
 
 Api.init
   host: if !!location.href.match /demo|beta/
-    'https://dev.zooniverse.org'
+    'https://olddev.zooniverse.org'
   else if +location.port < 1024
     'https://api.zooniverse.org'
   else
-    'https://dev.zooniverse.org'
+    'https://olddev.zooniverse.org'
     #"#{location.protocol}//#{location.hostname}:3000"
 
 # TODO: Don't count on the proxy frame to have no loaded yet.

--- a/app/lib/analytics.coffee
+++ b/app/lib/analytics.coffee
@@ -16,7 +16,8 @@ buildEventData = (type, related_id = null, subject_id = ExperimentalSubject.curr
   eventData['experiment'] = Experiments.ACTIVE_EXPERIMENT
   eventData['errorCode'] = ""
   eventData['errorDescription'] = ""
-  #eventData['cohort'] = Experiments.currentCohort
+  if Experiments.currentCohort?
+    eventData['cohort'] = Experiments.currentCohort
   eventData['userID'] = "(anonymous)"
   eventData
 

--- a/app/lib/analytics.coffee
+++ b/app/lib/analytics.coffee
@@ -2,8 +2,7 @@ $ = require('jqueryify')
 User = require 'zooniverse/lib/models/user'
 ExperimentalSubject = require 'models/experimental_subject'
 Experiments = require 'lib/experiments'
-getIP = require 'lib/getip'
-currentUserID = null
+UserGetter = require 'lib/userID'
 
 iteration = 0
 
@@ -17,19 +16,23 @@ buildEventData = (type, related_id = null, subject_id = ExperimentalSubject.curr
   eventData['experiment'] = Experiments.ACTIVE_EXPERIMENT
   eventData['errorCode'] = ""
   eventData['errorDescription'] = ""
-  eventData['cohort'] = Experiments.currentCohort
+  #eventData['cohort'] = Experiments.currentCohort
   eventData['userID'] = "(anonymous)"
   eventData
 
-addUserDetailsToEventData = (eventData, user_id = User.current?.zooniverse_id) ->
-  getIP.getUserIDorIPAddress()
+addUserDetailsToEventData = (eventData) ->
+  eventualUserIdentifier = new $.Deferred
+  UserGetter.getUserIDorIPAddress()
   .then (data) =>
     if data?
-      currentUserID = data
-  .fail (data) =>
-    currentUserID = "(anonymous)"
+      UserGetter.currentUserID = data
+  .fail =>
+    UserGetter.currentUserID = "(anonymous)"
   .always =>
-    eventData['userID'] = currentUserID
+    eventData['userID'] = UserGetter.currentUserID
+    eventualUserIdentifier.resolve eventData
+  eventualUserIdentifier.promise()
+
 
 addCohortToEventData = (eventData) ->
   eventualEventData = new $.Deferred
@@ -37,6 +40,7 @@ addCohortToEventData = (eventData) ->
   .then (cohort) =>
     if cohort?
       eventData['cohort'] = cohort
+      Experiments.currentCohort = cohort
   .always =>
     eventualEventData.resolve eventData
   eventualEventData.promise()
@@ -69,9 +73,9 @@ logToGoogle = (eventData) =>
 ###
 This will log a user interaction both in the Geordi analytics API and in Google Analytics.
 ###
-logEvent = (type, related_id = '', user_id = User.current?.zooniverse_id, subject_id = ExperimentalSubject.current?.zooniverseId) =>
+logEvent = (type, related_id = '', subject_id = ExperimentalSubject.current?.zooniverseId) =>
   eventData = buildEventData(type, related_id, subject_id)
-  addUserDetailsToEventData(eventData, user_id)
+  addUserDetailsToEventData(eventData)
   .always (eventData) =>
     if Experiments.currentCohort?
       logToGeordi eventData
@@ -85,14 +89,12 @@ logEvent = (type, related_id = '', user_id = User.current?.zooniverse_id, subjec
 ###
 This will log an error in Geordi only. In order to guarantee that this works, no new AJAX calls for cohort or user IP are initiated
 ###
-logError = (error_code, error_description, type, related_id = '', user_id = User.current?.zooniverse_id, subject_id = ExperimentalSubject.current?.zooniverseId) ->
+logError = (error_code, error_description, type, related_id = '', subject_id = ExperimentalSubject.current?.zooniverseId) ->
   eventData = buildEventData(type, related_id, subject_id)
   eventData['errorCode'] = error_code
   eventData['errorDescription'] = error_description
-  eventData['userID'] = if currentUserID? then currentUserID else if user_id? then user_id else "(anonymous)"
+  eventData['userID'] = if UserGetter.currentUserID? then UserGetter.currentUserID else if User.current?.zooniverse_id? then User.current?.zooniverse_id else "(anonymous)"
   logToGeordi eventData
 
 exports.logEvent = logEvent
 exports.logError = logError
-exports.getUserIDorIPAddress = getUserIDorIPAddress
-

--- a/app/lib/analytics.coffee
+++ b/app/lib/analytics.coffee
@@ -22,19 +22,14 @@ buildEventData = (type, related_id = null, subject_id = ExperimentalSubject.curr
   eventData
 
 addUserDetailsToEventData = (eventData, user_id = User.current?.zooniverse_id) ->
-  eventualEventData = new $.Deferred
-  eventData['userID'] = if user_id? then user_id else if currentUserID? then currentUserID else null
-  if eventData['userID']?
-    eventualEventData.resolve eventData
-  else
-    getIP.getClientOrigin()
-    .then (data) =>
-      if data?
-        currentUserID = getIP.getNiceOriginString data
-        eventData['userID'] = currentUserID
-    .always =>
-      eventualEventData.resolve eventData
-  eventualEventData.promise()
+  getIP.getUserIDorIPAddress()
+  .then (data) =>
+    if data?
+      currentUserID = data
+  .fail (data) =>
+    currentUserID = "(anonymous)"
+  .always =>
+    eventData['userID'] = currentUserID
 
 addCohortToEventData = (eventData) ->
   eventualEventData = new $.Deferred
@@ -99,4 +94,5 @@ logError = (error_code, error_description, type, related_id = '', user_id = User
 
 exports.logEvent = logEvent
 exports.logError = logError
+exports.getUserIDorIPAddress = getUserIDorIPAddress
 

--- a/app/lib/experiments.coffee
+++ b/app/lib/experiments.coffee
@@ -16,7 +16,7 @@ ACTIVE_EXPERIMENT = "SerengetiBlanksExperiment1"
 The URL of the experiment server to use
 ###
 # prod:
-EXPERIMENT_SERVER_URL = "http://experiments.staging.zooniverse.org/"
+EXPERIMENT_SERVER_URL = "http://experiments.zooniverse.org/"
 # dev:
 #EXPERIMENT_SERVER_URL = "http://localhost:4567/"
 

--- a/app/lib/experiments.coffee
+++ b/app/lib/experiments.coffee
@@ -9,21 +9,29 @@ AnalyticsLogger = require 'lib/analytics'
 Define the active experiment here by using a string which exists in http://experiments.zooniverse.org/active_experiments
 If no experiments should be running right now, set this to null, false or ""
 ###
-ACTIVE_EXPERIMENT = null
+ACTIVE_EXPERIMENT = "SerengetiBlanksExperiment1"
 
 ###
 The URL of the experiment server to use
 ###
 # prod:
-EXPERIMENT_SERVER_URL = "http://experiments.zooniverse.org/"
+EXPERIMENT_SERVER_URL = "http://experiments.staging.zooniverse.org/"
 # dev:
 #EXPERIMENT_SERVER_URL = "http://localhost:4567/"
 
 COHORT_CONTROL = "control"
+COHORT_0 = "0"
+COHORT_20 = "20"
+COHORT_40 = "40"
+COHORT_60 = "60"
+COHORT_80 = "80"
+COHORT_INELIGIBLE = "ineligible"
 COHORT_INSERTION = "interesting"
 SOURCE_INSERTED = "Inserted From Set"
 SOURCE_RANDOM = "Random From Set"
 SOURCE_NORMAL = "Normal Random"
+SOURCE_BLANK = "Blank"
+SOURCE_NON_BLANK = Non-Blank"
 
 ###
 When an error is encountered from the experiment server, this is the period, in milliseconds, that the code below will wait before any further attempts to contact it.
@@ -55,16 +63,17 @@ sources = {}
 ###
 Do not modify this initialization, it is used to track any changes of cohort for this user
 ###
-fallbackReason = null
+excludedReason = null
 
 ###
 when we first get participant, and the user has not started experiment in a previous sessions, we'll need to log it to Geordi
 ###
 checkForExperimentStartAndLogIt = (participant) ->
-  if participant.insertion_subjects_seen.length==0 && participant.num_random_subjects_seen==0
+  if participant.blank_subjects_seen.length==0 && participant.non_blank_subjects_seen.length==0
     AnalyticsLogger.logEvent 'experimentStart'
 
 ###
+  TODO fix this
 when we get cohort, and it has changed from interesting to control, must be end of experiment, we'll need to log it to Geordi
 ###
 checkForExperimentEndAndLogIt = (oldCohort,newCohort) ->
@@ -74,44 +83,53 @@ checkForExperimentEndAndLogIt = (oldCohort,newCohort) ->
 ###
 when we get participant, we need to log to Geordi if the user's cohort was changed
 ###
-checkForFallbackAndLogIt = (participant) ->
-  if !fallbackReason? && participant.fallback
+checkForExcludedAndLogIt = (participant) ->
+  if !excludedReason? && participant.excluded
     # if not previously logged, log it.
-    fallbackReason = participant.fallback_reason
-    AnalyticsLogger.logEvent 'experimentFallback',participant.fallback_reason
+    excludedReason = participant.excluded_reason
+    AnalyticsLogger.logEvent 'experimentExcluded',participant.excluded_reason
 
 ###
 This method will contact the experiment server to find the participant(experimental data) for this user in the specified experiment
 ###
-getParticipant = (user_id = User.current?.zooniverse_id) ->
-  eventualParticipant = new $.Deferred
-  if ACTIVE_EXPERIMENT?
-    now = new Date().getTime()
-    if lastFailedAt?
-      timeSinceLastFail = now - lastFailedAt.getTime()
-    if lastFailedAt == null || timeSinceLastFail > RETRY_INTERVAL
-      try
-        $.get(EXPERIMENT_SERVER_URL+ 'experiment/' + ACTIVE_EXPERIMENT + '?user_id=' + user_id)
-        .then (participant) =>
-          checkForFallbackAndLogIt participant
-          checkForExperimentEndAndLogIt currentCohort,participant.cohort
-          currentCohort = participant.cohort
-          if !currentParticipant?
-            AnalyticsLogger.logEvent 'experimentResume'
-            checkForExperimentStartAndLogIt participant
-          currentParticipant = participant
-          eventualParticipant.resolve participant
-        .fail =>
-          lastFailedAt = new Date()
-          AnalyticsLogger.logError "500", "Couldn't retrieve experimental participant data", "error"
+getParticipant = () ->
+  currentUserID = "(unknown)"
+  AnalyticsLogger.getUserIDorIPAddress()
+  .then (data) =>
+    if data?
+      currentUserID = data
+  .fail (data) =>
+    currentUserID = "(anonymous)"
+  .always =>
+    user_id = currentUserID
+    eventualParticipant = new $.Deferred
+    if ACTIVE_EXPERIMENT?
+      now = new Date().getTime()
+      if lastFailedAt?
+        timeSinceLastFail = now - lastFailedAt.getTime()
+      if lastFailedAt == null || timeSinceLastFail > RETRY_INTERVAL
+        try
+          $.get(EXPERIMENT_SERVER_URL+ 'experiment/' + ACTIVE_EXPERIMENT + '?user_id=' + user_id)
+          .then (participant) =>
+            checkForExcludedAndLogIt participant
+            checkForExperimentEndAndLogIt currentCohort,participant.cohort
+            currentCohort = participant.cohort
+            if !currentParticipant?
+              AnalyticsLogger.logEvent 'experimentResume'
+              checkForExperimentStartAndLogIt participant
+            currentParticipant = participant
+            eventualParticipant.resolve participant
+          .fail =>
+            lastFailedAt = new Date()
+            AnalyticsLogger.logError "500", "Couldn't retrieve experimental participant data", "error"
+            eventualParticipant.resolve null
+        catch error
           eventualParticipant.resolve null
-      catch error
+      else
         eventualParticipant.resolve null
     else
       eventualParticipant.resolve null
-  else
-    eventualParticipant.resolve null
-  eventualParticipant.promise()
+    eventualParticipant.promise()
 
 ###
 This method will contact the experiment server to find the cohort for this user in the specified experiment
@@ -156,4 +174,12 @@ exports.COHORT_INSERTION = COHORT_INSERTION
 exports.SOURCE_INSERTED = SOURCE_INSERTED
 exports.SOURCE_RANDOM = SOURCE_RANDOM
 exports.SOURCE_NORMAL = SOURCE_NORMAL
+exports.SOURCE_BLANK = SOURCE_BLANK
+exports.SOURCE_NON_BLANK = SOURCE_NON_BLANK
+exports.COHORT_0 = COHORT_0
+exports.COHORT_20 = COHORT_20
+exports.COHORT_40 = COHORT_40
+exports.COHORT_60 = COHORT_60
+exports.COHORT_80 = COHORT_80
+exports.COHORT_INELIGIBLE = COHORT_INELIGIBLE
 exports.sources = sources

--- a/app/lib/experiments.coffee
+++ b/app/lib/experiments.coffee
@@ -72,6 +72,16 @@ Do not modify this initialization, it is used to track when the user has finishe
 experimentCompleted = false
 
 ###
+Upon logout, user must be forgotten
+###
+resetExperimentalFlags = =>
+  experimentCompleted = false
+  excludedReason = null
+  currentCohort = null
+  currentParticipant = null
+  UserGetter.currentUserID = null
+
+###
 when we first get participant, and the user has not started experiment in a previous sessions, we'll need to log it to Geordi
 ###
 checkForExperimentStartAndLogIt = (participant) ->
@@ -104,7 +114,7 @@ getParticipant = () ->
   .then (data) =>
     if data?
       UserGetter.currentUserID = data.toString()
-  .fail (data) =>
+  .fail =>
     UserGetter.currentUserID = "(anonymous)"
   .always =>
     eventualParticipant = new $.Deferred
@@ -189,3 +199,4 @@ exports.COHORT_60 = COHORT_60
 exports.COHORT_80 = COHORT_80
 exports.COHORT_INELIGIBLE = COHORT_INELIGIBLE
 exports.sources = sources
+exports.resetExperimentalFlags = resetExperimentalFlags

--- a/app/lib/getip.coffee
+++ b/app/lib/getip.coffee
@@ -1,3 +1,5 @@
+User = require 'zooniverse/lib/models/user'
+
 getClientOrigin = ->
   eventualIP = new $.Deferred
   $.get('http://jsonip.appspot.com/')
@@ -18,5 +20,19 @@ getNiceOriginString = (data) ->
   else
     "(anonymous)"
 
+getUserIDorIPAddress = (user_id = User.current?.zooniverse_id) ->
+  eventualUserID = new $.Deferred
+  if user_id?
+    eventualUserID.resolve user_id
+  else
+    getIP.getClientOrigin()
+    .then (data) =>
+      if data?
+        user_id = getNiceOriginString data
+    .always =>
+      eventualUserID.resolve user_id
+  eventualUserID.promise()
+
 exports.getClientOrigin = getClientOrigin
 exports.getNiceOriginString = getNiceOriginString
+exports.getUserIDorIPAddress = getUserIDorIPAddress

--- a/app/lib/userID.coffee
+++ b/app/lib/userID.coffee
@@ -3,9 +3,9 @@ currentUserID = null
 
 getClientOrigin = ->
   eventualIP = new $.Deferred
-  $.get('http://jsonip.appspot.com/')
-  .then (data) =>
-    eventualIP.resolve data
+  $.get('https://api.ipify.org')
+  .then (ip) =>
+    eventualIP.resolve {ip: ip, address: ip}
   .fail =>
     eventualIP.resolve {ip: '?.?.?.?', address: '(anonymous)'}
   eventualIP.promise()
@@ -24,7 +24,7 @@ getNiceOriginString = (data) ->
 getUserIDorIPAddress = =>
   eventualUserID = new $.Deferred
   if currentUserID?
-    eventualUserID.resolve user_id
+    eventualUserID.resolve currentUserID
   else if User.current?.zooniverse_id
     eventualUserID.resolve User.current?.zooniverse_id
   else

--- a/app/lib/userID.coffee
+++ b/app/lib/userID.coffee
@@ -23,7 +23,11 @@ getNiceOriginString = (data) ->
 
 getUserIDorIPAddress = =>
   eventualUserID = new $.Deferred
-  if currentUserID?
+  if User.current?.zooniverse_id && currentUserID!=User.current?.zooniverse_id
+    # if a current ID is stored, but user's current ID is something different (e.g. anon IP), overwrite previous
+    currentUserID = User.current?.zooniverse_id
+    eventualUserID.resolve User.current?.zooniverse_id
+  else if currentUserID?
     eventualUserID.resolve currentUserID
   else if User.current?.zooniverse_id
     eventualUserID.resolve User.current?.zooniverse_id

--- a/app/lib/userID.coffee
+++ b/app/lib/userID.coffee
@@ -1,4 +1,5 @@
 User = require 'zooniverse/lib/models/user'
+currentUserID = null
 
 getClientOrigin = ->
   eventualIP = new $.Deferred
@@ -20,19 +21,22 @@ getNiceOriginString = (data) ->
   else
     "(anonymous)"
 
-getUserIDorIPAddress = (user_id = User.current?.zooniverse_id) ->
+getUserIDorIPAddress = =>
   eventualUserID = new $.Deferred
-  if user_id?
+  if currentUserID?
     eventualUserID.resolve user_id
+  else if User.current?.zooniverse_id
+    eventualUserID.resolve User.current?.zooniverse_id
   else
-    getIP.getClientOrigin()
+    getClientOrigin()
     .then (data) =>
       if data?
-        user_id = getNiceOriginString data
+        currentUserID = getNiceOriginString data
     .always =>
-      eventualUserID.resolve user_id
+      eventualUserID.resolve currentUserID
   eventualUserID.promise()
 
 exports.getClientOrigin = getClientOrigin
 exports.getNiceOriginString = getNiceOriginString
 exports.getUserIDorIPAddress = getUserIDorIPAddress
+exports.currentUserID = currentUserID

--- a/app/models/experimental_subject.coffee
+++ b/app/models/experimental_subject.coffee
@@ -92,7 +92,6 @@ class ExperimentalSubject extends Subject
           if nextSubjectIDs? && nextSubjectIDs.length == 0
             # end of experiment
             Experiments.currentParticipant.active = false
-            AnalyticsLogger.logEvent 'experimentEnd'
           else
             for subjectIDAndBlankness in nextSubjectIDs
               [subjectID, blankness] = subjectIDAndBlankness.split(":")

--- a/app/models/subject.coffee
+++ b/app/models/subject.coffee
@@ -4,6 +4,7 @@ Api = require 'zooniverse/lib/api'
 seasons = require 'lib/seasons'
 User = require 'zooniverse/lib/models/user'
 Subject = require 'models/experimental_subject'
+UserGetter = require 'lib/userID'
 
 class Subject extends Model
   @configure 'Subject', 'zooniverseId', 'workflowId', 'location', 'coords', 'metadata'
@@ -30,7 +31,7 @@ class Subject extends Model
       @trigger 'no-subjects'
     else
       subject = @first()
-      AnalyticsLogger.logEvent 'view',null,User.current?.zooniverse_id,subject.zooniverseId
+      AnalyticsLogger.logEvent 'view'
       subject.select()
 
   # ensures that the next subject is selected, either now or once deferred chain is complete


### PR DESCRIPTION
This changelist will:
1. Launch the blank images experiment (6 cohorts - random, 0% blank, 20% blank, 40,60,80% blank)
2. Ensure anonymous users get a cohort correctly
3. Improve user ID storage & retrieval
4. Update to use a new anon IP identification service
5. Remove the "fallback to control" concept - no-one ever changes cohort
6. Fix some missing fields with Geordi logging
7. Improve Geordi logging syntax