### PR TITLE
Season 9 Launch

### DIFF
--- a/app/index.coffee
+++ b/app/index.coffee
@@ -67,8 +67,13 @@ Api.proxy.el().one 'load', ->
       {season, id, name, total, complete}
 
     sortedSeasons.sort (a, b) ->
-      return 1 if a.season is '0'
-      a.season > b.season
+      # Lost Season is effectively season 8.5, in ordering
+      if a.season is '0'
+        8.5 - b.season
+      else if b.season is '0'
+        a.season - 8.5
+      else
+        a.season - b.season
 
     seasons.push sortedSeasons...
 

--- a/app/views/home_page.eco
+++ b/app/views/home_page.eco
@@ -1,7 +1,7 @@
 <% translate = require 't7e' %>
 <% seasons = require 'lib/seasons' %>
 
-<% allSeasonsComplete = true %>
+<% allSeasonsComplete = false %>
 
 <div class="recents">
   <div class="image-changer"></div>

--- a/css/home_page.styl
+++ b/css/home_page.styl
@@ -85,7 +85,7 @@
       .season {
         display: inline-block;
         vertical-align: middle;
-        width: 75px;
+        width: 90px;
       }
 
       .track {
@@ -94,7 +94,7 @@
         outer-deboss: 2px;
         position: relative;
         vertical-align: middle;
-        width: 205px;
+        width: 190px;
 
         &:before {
           border-radius: 5px;

--- a/css/home_page.styl
+++ b/css/home_page.styl
@@ -85,7 +85,9 @@
       .season {
         display: inline-block;
         vertical-align: middle;
+        text-align: right;
         width: 90px;
+        padding-right: 10px;
       }
 
       .track {
@@ -94,7 +96,7 @@
         outer-deboss: 2px;
         position: relative;
         vertical-align: middle;
-        width: 190px;
+        width: 180px;
 
         &:before {
           border-radius: 5px;


### PR DESCRIPTION
Put Lost Season in correct chronological order. 
CSS fix to better fit in the "Lost Season" text. 
Reenable progress bars for Season 9.