### PR TITLE
Redirect routes other than authors to related panoptes project

### DIFF
--- a/app/index.coffee
+++ b/app/index.coffee
@@ -12,7 +12,7 @@ Profile = require 'controllers/profile'
 DataPage = require 'controllers/data_page'
 Api = require 'Zooniverse/lib/api'
 seasons = require 'lib/seasons'
-TopBar = require 'Zooniverse/lib/controllers/top_bar'
+# TopBar = require 'Zooniverse/lib/controllers/top_bar'
 User = require 'Zooniverse/lib/models/user'
 ExperimentalSubject = require 'models/experimental_subject'
 Geordi = require 'lib/geordi_and_experiments_setup'
@@ -39,6 +39,13 @@ googleAnalytics.init
 
 app = {}
 
+# REDIRECT TO SNAPSHOT SERENGETI PANOPTES PROJECT
+unless window.location.hash is "#/authors" or window.location.hash is "#/data"
+  window.location.replace 'https://www.zooniverse.org/projects/zooniverse/snapshot-serengeti'
+
+if window.location.hash is "#/data"
+  window.location.replace 'https://www.zooniverse.org/projects/zooniverse/snapshot-serengeti/about/results'
+
 User.bind 'sign-in', ->
   $('html').toggleClass 'signed-in', User.current?
   if User.current?
@@ -64,10 +71,10 @@ Api.proxy.el().one 'load', ->
       total ?= 0
       complete ?= 0
       name = if season is '0'
-        'Lost Season' 
+        'Lost Season'
       else if season is '999'
         'Season 9.5'
-      else 
+      else
         "Season #{ season }"
       {season, id, name, total, complete}
 
@@ -103,9 +110,9 @@ Api.proxy.el().one 'load', ->
 
       routes:
         '/home': 'home'
-        '/about': 'about'
-        '/classify': 'classify'
-        '/profile': 'profile',
+        # '/about': 'about'
+        # '/classify': 'classify'
+        # '/profile': 'profile',
         '/authors': 'authors'
         # '/explore': 'explore'
         '/data': 'data'
@@ -113,14 +120,14 @@ Api.proxy.el().one 'load', ->
       default: 'home'
 
     # Load the top bar last since it fetches the user.
-    app.topBar = new TopBar
-      app: 'serengeti'
-      appName: 'Snapshot Serengeti'
+    # app.topBar = new TopBar
+    #   app: 'serengeti'
+    #   appName: 'Snapshot Serengeti'
 
-    $(window).on 'request-login-dialog', ->
-      app.topBar.onClickSignUp()
-      app.topBar.loginForm.signInButton.click()
-      app.topBar.loginDialog.reattach()
+    # $(window).on 'request-login-dialog', ->
+    #   app.topBar.onClickSignUp()
+    #   app.topBar.loginForm.signInButton.click()
+    #   app.topBar.loginDialog.reattach()
 
     $(window).bind('beforeunload', (e) ->
         Geordi.logEvent 'leave'
@@ -128,7 +135,7 @@ Api.proxy.el().one 'load', ->
     )
 
     app.stack.el.appendTo 'body'
-    app.topBar.el.prependTo 'body'
+    # app.topBar.el.prependTo 'body'
 
     Route.setup()
 

--- a/app/translations/en_us.coffee
+++ b/app/translations/en_us.coffee
@@ -863,9 +863,10 @@ module.exports =
       '''
       sidebar: '''
         <h3>Data from Seasons 1-6 have resulted in the following publications:</h3>
+        <p><a href="http://zooniverse.org/publications">Zooniverse Publications</a></p>
+
         <h4>Swanson, A. 2014. Living with lions: spatiotemporal aspects of coexistence in savanna carnivores. </h4>
         <p>Ali's Dissertation used camera traps to explore how lions, hyenas, cheetahs, and African wild dogs manage to coexist.</p>
-        <p><a href="http://gradworks.umi.com/36/43/3643700.html">View this publication online</a></p>
 
         <h4> Cusack, J., Swanson, A., Coulson, C., Packer, C., Carbone, C., Dickman, A., Kosmala, M., Lintott, C., Rowcliffe, M. In Review. Applying a random encounter model to estimate lion density from camera traps in Serengeti National Park, Tanzania </h4>
         <p>Currently in review, this paper uses the camera trap photo rates to estimate lion densities. The aim is to test this in Serengeti, where we know the actual lion numbers, and eventually apply this as a conservation method elsewhere.</p>

--- a/app/translations/en_us.coffee
+++ b/app/translations/en_us.coffee
@@ -9,7 +9,7 @@ module.exports =
     authors: 'Authors'
 
   home:
-    heading: 'Welcome to Snapshot Serengeti'
+    heading: 'Redirecting to the live Snapshot Serengeti...'
     content: '''
       Hundreds of camera traps in Serengeti National Park, Tanzania,
       are providing a powerful new window into the dynamics of Africa’s most elusive wildlife species.

--- a/app/views/navigation.eco
+++ b/app/views/navigation.eco
@@ -1,21 +1,9 @@
 <% translate = require 't7e' %>
 
 <h1>
-  <a href="/">
+  <a href="https://www.zooniverse.org/projects/zooniverse/snapshot-serengeti">
     <img class="mobile-wordmark" src="images/wordmark-stacked.svg" alt="Snapshot Serengeti" />
     <img class="desktop-wordmark" src="images/wordmark.png" alt="Snapshot Serengeti" />
   </a>
   <button class="nav-button"></button>
 </h1>
-
-<nav>
-  <ul>
-    <li><%- translate 'a', 'navigation.home', href: '#/home' %></li>
-    <li><%- translate 'a', 'navigation.about', href: '#/about' %></li>
-    <li><%- translate 'a', 'navigation.classify', href: '#/classify' %></li>
-    <li><%- translate 'a', 'navigation.profile', href: '#/profile' %></li>
-    <li><%- translate 'a', 'navigation.discuss', href: 'https://talk.snapshotserengeti.org/' %></li>
-    <li><%- translate 'a', 'navigation.blog', href: 'http://blog.snapshotserengeti.org/' %></li>
-    <li><%- translate 'a', 'navigation.authors', href: '#/authors' %></li>
-  </ul>
-</nav>


### PR DESCRIPTION
Closes #159. 

Staged:
- root (should redirect, hard to tell but heading changed to "Redirecting to the live Snapshot Serengeti..."): https://preview.zooniverse.org/serengeti/
- #/home (same as above): https://preview.zooniverse.org/serengeti/#/home
- #/authors: https://preview.zooniverse.org/serengeti/#/authors
- #/data (should redirect to new project results page): https://preview.zooniverse.org/serengeti/#/data

Changes:
- add redirect to related Panoptes project if route is not "#/authors" or "#/data"
- if "#/authors" then load authors page
- if "#/data" then redirect to related Panoptes project research page

Notes:
- fix for vulnerabilities incoming, to be included with production deploy